### PR TITLE
initial work towards reintegrating the testsuite exporter plugin

### DIFF
--- a/backend/src/main/java/de/learnlib/alex/testing/export/TestCaseExport.java
+++ b/backend/src/main/java/de/learnlib/alex/testing/export/TestCaseExport.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 TU Dortmund
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.learnlib.alex.testing.export;
+
+import java.util.List;
+
+import de.learnlib.alex.data.entities.ParameterizedSymbol;
+
+/**
+ * @author Philip Koch
+ * @author frohme
+ */
+public class TestCaseExport {
+
+    private final String name;
+
+    private final List<ParameterizedSymbol> symbols;
+
+    private final List<String> outputs;
+
+    public TestCaseExport(String name, List<ParameterizedSymbol> symbols, List<String> outputs) {
+        this.name = name;
+        this.symbols = symbols;
+        this.outputs = outputs;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<ParameterizedSymbol> getSymbols() {
+        return symbols;
+    }
+
+    public List<String> getOutputs() {
+        return outputs;
+    }
+}

--- a/backend/src/main/java/de/learnlib/alex/testing/export/TestSuiteExport.java
+++ b/backend/src/main/java/de/learnlib/alex/testing/export/TestSuiteExport.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 TU Dortmund
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.learnlib.alex.testing.export;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import de.learnlib.alex.testing.entities.Test;
+import de.learnlib.alex.testing.entities.TestCase;
+import de.learnlib.alex.testing.entities.TestCaseStep;
+import de.learnlib.alex.testing.entities.TestSuite;
+
+/**
+ * @author Philip Koch
+ * @author frohme
+ */
+public class TestSuiteExport {
+
+    private final String projectURL;
+
+    private final List<TestCaseExport> testCases;
+
+    private final String name;
+
+    public TestSuiteExport(String projectURL, TestSuite suite, String name) {
+        this.name = name;
+        this.projectURL = projectURL;
+        this.testCases = new ArrayList<>();
+        for (Test test : suite.getTests()) {
+            TestCase testCase = (TestCase) test;
+
+            final int testCaseSize =
+                    testCase.getPreSteps().size() + testCase.getSteps().size() + testCase.getPostSteps().size();
+            final List<TestCaseStep> testCaseSteps = new ArrayList<>(testCaseSize);
+
+            testCaseSteps.addAll(testCase.getPreSteps());
+            testCaseSteps.addAll(testCase.getSteps());
+            testCaseSteps.addAll(testCase.getPostSteps());
+
+            this.testCases.add(new TestCaseExport(testCase.getName(),
+                                                  testCaseSteps.stream()
+                                                               .map(TestCaseStep::getPSymbol)
+                                                               .collect(Collectors.toList()),
+                                                  testCaseSteps.stream()
+                                                               .map(TestCaseStep::getExpectedResult)
+                                                               .collect(Collectors.toList())));
+        }
+
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getProjectURL() {
+        return projectURL;
+    }
+
+    public List<TestCaseExport> getTestCases() {
+        return testCases;
+    }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 TU Dortmund
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>alex-parent</artifactId>
+        <groupId>de.learnlib.alex</groupId>
+        <version>1.6.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>plugins-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>ALEX :: Plugins Parent</name>
+
+    <modules>
+        <module>testsuite-generator</module>
+        <module>testsuite-generator-test</module>
+    </modules>
+
+</project>

--- a/plugins/testsuite-generator-test/pom.xml
+++ b/plugins/testsuite-generator-test/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 TU Dortmund
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>de.learnlib.alex</groupId>
+        <artifactId>plugins-parent</artifactId>
+        <version>1.6.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>testsuite-generator-maven-plugin-test</artifactId>
+    <packaging>jar</packaging>
+
+    <name>ALEX :: Plugin :: Testsuite Generator Maven Plugin Test</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>de.learnlib.alex</groupId>
+            <artifactId>alex-backend</artifactId>
+            <scope>test</scope>
+            <classifier>classes</classifier>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>de.learnlib.alex</groupId>
+            <artifactId>alex-backend</artifactId>
+            <scope>test</scope>
+            <type>war</type>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+            <version>6.10</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin><!-- Do not deploy binaries -->
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>de.learnlib.alex</groupId>
+                <artifactId>testsuite-generator-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <sourceFile>${project.build.testSourceDirectory}/example.json</sourceFile>
+                    <driverPath>/usr/bin/chromedriver</driverPath>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/plugins/testsuite-generator/pom.xml
+++ b/plugins/testsuite-generator/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 TU Dortmund
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>de.learnlib.alex</groupId>
+        <artifactId>plugins-parent</artifactId>
+        <version>1.6.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>testsuite-generator-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+
+    <name>ALEX :: Plugin :: Testsuite Generator Maven Plugin</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.5.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>de.learnlib.alex</groupId>
+            <artifactId>alex-backend</artifactId>
+            <classifier>classes</classifier>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>3.7.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.10</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+            <version>4.0.8</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/plugins/testsuite-generator/src/main/java/de/learnlib/alex/plugin/TestSuiteGeneratorMojo.java
+++ b/plugins/testsuite-generator/src/main/java/de/learnlib/alex/plugin/TestSuiteGeneratorMojo.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2018 TU Dortmund
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.learnlib.alex.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.learnlib.alex.data.entities.ParameterizedSymbol;
+import de.learnlib.alex.testing.export.TestCaseExport;
+import de.learnlib.alex.testing.export.TestSuiteExport;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.stringtemplate.v4.ST;
+
+/**
+ * @author Philip Koch
+ * @author frohme
+ */
+@Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_TEST_RESOURCES)
+public class TestSuiteGeneratorMojo extends AbstractMojo {
+
+    @Parameter(required = true)
+    private File sourceFile;
+
+    @Parameter(required = true)
+    private String driverPath;
+
+    @Parameter(defaultValue = "${project.build.directory}/generated-test-sources", required = true)
+    private File targetDirectory;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        final TestSuiteExport export;
+
+        try {
+            export = mapper.readValue(sourceFile, TestSuiteExport.class);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error reading export file", e);
+        }
+
+        final List<TestCaseExport> testCases = export.getTestCases();
+
+        writeAbstractSuperClass(export);
+
+        for (int i = 0; i < testCases.size(); i++) {
+            final TestCaseExport testCase = testCases.get(i);
+            writeTestCase(testCase, i);
+        }
+
+        writeTestSuiteConfiguration(export);
+    }
+
+    private void writeAbstractSuperClass(TestSuiteExport export) throws MojoExecutionException {
+        final ST template = getTemplate("/abstractTest.st");
+
+        template.add("driverPath", this.driverPath);
+        template.add("exportFileName", this.sourceFile.getName());
+        template.add("projectUrl", export.getProjectURL());
+
+        writeToFile(template.render(), fileWithPackage("AbstractExportedTest.java"));
+    }
+
+    private void writeTestCase(TestCaseExport export, int idx) throws MojoExecutionException {
+        final ST template = getTemplate("/testCase.st");
+
+        template.add("testName", export.getName());
+        template.add("testClassName", escape(export.getName()));
+        template.add("testCaseIndex", idx);
+
+        final StringBuilder testMethodBuilder = new StringBuilder();
+
+        for (int i = 0; i < export.getSymbols().size(); i++) {
+            testMethodBuilder.append(generateTestCaseMethod(export, 0));
+        }
+
+        template.add("testCases", testMethodBuilder.toString());
+
+        writeToFile(template.render(), fileWithPackage(escape(export.getName()) + ".java"));
+    }
+
+    private void writeTestSuiteConfiguration(TestSuiteExport export) throws MojoExecutionException {
+        final ST template = getTemplate("/testSuiteConfiguration.st");
+
+        template.add("testSuiteName", export.getName());
+
+        final List<String> testCaseNames = export.getTestCases()
+                                                 .stream()
+                                                 .map(TestCaseExport::getName)
+                                                 .map(TestSuiteGeneratorMojo::escape)
+                                                 .collect(Collectors.toList());
+
+        template.add("testCaseNames", testCaseNames);
+
+        writeToFile(template.render(), new File(escape(export.getName()) + ".xml"));
+    }
+
+    private String generateTestCaseMethod(TestCaseExport export, int idx) throws MojoExecutionException {
+        final ST template = getTemplate("/testCaseMethod.st");
+
+        final ParameterizedSymbol input = export.getSymbols().get(idx);
+        final String output = export.getOutputs().get(idx);
+
+        template.add("testName", input.getSymbol().getName());
+        template.add("output", output);
+        template.add("testMethodMethod", escape(input.getSymbol().getName()));
+        template.add("testMethodIndex", idx);
+
+        if (idx > 0) {
+            template.add("previousTestMethodName", escape(export.getSymbols().get(idx - 1).getSymbol().getName()));
+        }
+
+        return template.render();
+    }
+
+    private ST getTemplate(String templatePath) throws MojoExecutionException {
+        try (InputStream is = TestSuiteGeneratorMojo.class.getResourceAsStream(templatePath)) {
+            return new ST(IOUtils.toString(is, StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new MojoExecutionException("Could not read template", e);
+        }
+    }
+
+    private File fileWithPackage(final String fileName) {
+        return this.targetDirectory.toPath().resolve("/de/learnlib/alex/plugin/generated").resolve(fileName).toFile();
+    }
+
+    private void writeToFile(final String content, final File dest) throws MojoExecutionException {
+        try {
+            FileUtils.write(dest, content, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Could not write file", e);
+        }
+    }
+
+    private static String escape(String src) {
+        return src.replaceAll("\\W", "_");
+    }
+}
+

--- a/plugins/testsuite-generator/src/main/resources/abstractTest.st
+++ b/plugins/testsuite-generator/src/main/resources/abstractTest.st
@@ -1,0 +1,64 @@
+package de.learnlib.alex.plugin.generated;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.learnlib.alex.data.entities.Project;
+import de.learnlib.alex.data.entities.Symbol;
+import de.learnlib.alex.data.entities.SymbolAction;
+import de.learnlib.alex.learning.entities.webdrivers.ChromeDriverConfig;
+import de.learnlib.alex.learning.services.connectors.ConnectorManager;
+import de.learnlib.alex.learning.services.connectors.VariableStoreConnector;
+import de.learnlib.alex.learning.services.connectors.WebServiceConnector;
+import de.learnlib.alex.learning.services.connectors.WebSiteConnector;
+import de.learnlib.alex.testsuites.dao.TestCaseExport;
+import de.learnlib.alex.testsuites.dao.TestSuiteExport;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+
+public class AbstractExportedTest {
+
+    protected ConnectorManager cm;
+    private List<TestCaseExport> testCases;
+
+    @BeforeSuite
+    public void setupSuite() throws Exception {
+
+        final String driverPath = "<driverPath>";
+        System.setProperty("webdriver.chrome.driver", driverPath);
+
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        final TestSuiteExport export = mapper.readValue(AbstractExportedTest.class.getResourceAsStream("/<exportFileName>"),
+                                                        TestSuiteExport.class);
+
+        testCases = export.getTestCases();
+
+        final ChromeDriverConfig cdc = new ChromeDriverConfig();
+        final WebSiteConnector wsc = new WebSiteConnector("<projectUrl>", cdc);
+        final WebServiceConnector wService = new WebServiceConnector(wsc.getBaseUrl());
+        final VariableStoreConnector vsc = new VariableStoreConnector();
+
+        cdc.setHeadless(false);
+
+        wsc.reset();
+        wsc.getDriver().get(wsc.getBaseUrl());
+
+        cm = new ConnectorManager();
+        cm.addConnector(wsc);
+        cm.addConnector(wService);
+        cm.addConnector(vsc);
+
+    }
+
+    protected TestCaseExport getTestCase(int idx) {
+        return this.testCases.get(idx);
+    }
+
+    @AfterSuite
+    public void tearDownSuite() {
+        cm.dispose();
+    }
+}

--- a/plugins/testsuite-generator/src/main/resources/testCase.st
+++ b/plugins/testsuite-generator/src/main/resources/testCase.st
@@ -1,0 +1,28 @@
+package de.learnlib.alex.plugin.generated;
+
+import java.util.List;
+
+import de.learnlib.alex.data.entities.ExecuteResult;
+import de.learnlib.alex.data.entities.ParameterizedSymbol;
+import de.learnlib.alex.plugin.generated.AbstractExportedTest;
+import de.learnlib.alex.testing.export.TestCaseExport;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+// TestCase: <testName>
+public class <testClassName> extends AbstractExportedTest {
+
+    private List<ParameterizedSymbol> testCase;
+    private List<String> outcome;
+
+    @BeforeClass
+    public void setup() {
+        final TestCaseExport testCaseExport = super.getTestCase(<testCaseIndex>);
+        this.testCase = testCaseExport.getSymbols();
+        this.outcome = testCaseExport.getOutputs();
+    }
+
+    <testCases>
+
+}

--- a/plugins/testsuite-generator/src/main/resources/testCaseMethod.st
+++ b/plugins/testsuite-generator/src/main/resources/testCaseMethod.st
@@ -1,0 +1,8 @@
+
+    // Test: <testName>
+    // Expected Output: <output>
+    @Test<if(previousTestMethodName)>(dependsOnMethods = "<previousTestMethodName>")<endif>
+    public void <testMethodName>() {
+        ExecuteResult testResult = testCase.get(<testMethodIndex>).execute(super.cm);
+        Assert.assertEquals(testResult.getOutput(), outcome.get(<testMethodIndex>));
+    }

--- a/plugins/testsuite-generator/src/main/resources/testSuiteConfiguration.st
+++ b/plugins/testsuite-generator/src/main/resources/testSuiteConfiguration.st
@@ -1,0 +1,10 @@
+\<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+\<suite name ="<testSuiteName>">
+	\<test>
+		\<classes>
+			<testClassNames:{ tcn |
+			\<class name="<tcn>"/>
+			}>
+		\</classes>
+	\</test>
+\</suite>

--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.learnlib.alex</groupId>
@@ -90,7 +86,8 @@
         <module>backend</module>
         <module>build</module>
         <module>frontend</module>
-    </modules>
+        <module>plugins</module>
+  </modules>
 
     <!--===== properties ======-->
     <prerequisites>


### PR DESCRIPTION
Contains the basic infrastructure and the necessary components of the plugin.
However, the code is not yet activated (code for actually exporting a suite is
still missing) and the generator/generated code is completely untested.